### PR TITLE
Allow to work with newer RestSharp versions

### DIFF
--- a/TechTalk.JiraRestClient/JiraClient.cs
+++ b/TechTalk.JiraRestClient/JiraClient.cs
@@ -23,7 +23,7 @@ namespace TechTalk.JiraRestClient
             this.username = username;
             this.password = password;
             deserializer = new JsonDeserializer();
-            client = new RestClient { BaseUrl = baseUrl + (baseUrl.EndsWith("/") ? "" : "/") + "rest/api/2/" };
+            client = new RestClient(baseUrl + (baseUrl.EndsWith("/") ? "" : "/") + "rest/api/2/");
         }
 
         private RestRequest CreateRequest(Method method, String path)


### PR DESCRIPTION
RestSharp 105.0 changed the BaseUrl from being a string to an Uri.
This breaks the current implementation of the JiraClient.
Fortunately enough they kept the c'tor that takes a string, so
this change makes use of that. This allows JiraRestClient to be
used with both RestSharp 104.x and 105.x versions.

This fixes #9.

Please create a new nuget package after merging this fix.