### PR TITLE
Support for custom deserializers

### DIFF
--- a/TechTalk.JiraRestClient/JiraClient.cs
+++ b/TechTalk.JiraRestClient/JiraClient.cs
@@ -16,15 +16,21 @@ namespace TechTalk.JiraRestClient
     {
         private readonly string username;
         private readonly string password;
-        private readonly JsonDeserializer deserializer;
+        private readonly IDeserializer deserializer;
         private readonly string baseApiUrl;
+        
         public JiraClient(string baseUrl, string username, string password)
+            : this(baseUrl, username, password, new JsonDeserializer())
+        {
+        }
+        
+        public JiraClient(string baseUrl, string username, string password, IDeserializer deserializer)
         {
             this.username = username;
             this.password = password;
             
             baseApiUrl = new Uri(new Uri(baseUrl), "rest/api/2/").ToString();
-            deserializer = new JsonDeserializer();
+            this.deserializer = deserializer;
         }
 
         private RestRequest CreateRequest(Method method, String path)


### PR DESCRIPTION
Currently i have 2 jira instances, and they have different customfield IDs. I need my app to integrate to both of them, using the same CustomIssueFields class. My app.config file will decide which custom field ID will be used for each instance.

Despite my needs, this change adds flexibility to the library, someone else might find another use for it, but for me it is crucial for my app to work. I hope you guys consider it.

I know this will work only for deserialization, i will pull request the serialization part after this.

An example of how i will use it (my extension methods use JSON.NET, already tested on my local fork): 

``` C#
private class JsonDeserializer : IDeserializer 
{
    public T Deserialize<T>(IRestResponse response)
    {
        return response.Content.FromJson<T>(new DefaultJsonSerializerSettings(null, property =>
        {
            if (property.DeclaringType == typeof(CustomIssueFields) && property.PropertyName == "MySuiteTicket")
            {
                property.PropertyName = ConfigurationManager.AppSettings["JiraCustomFieldMySuiteTicket"];
            }
        }));
    }

    public string RootElement { get; set; }
    public string Namespace { get; set; }
    public string DateFormat { get; set; }
}

private class CustomIssueFields : IssueFields
{
   public string MySuiteTicket { get; set; }
}
```
