### PR TITLE
Support for fields outside the Issue class

### DIFF
--- a/TechTalk.JiraRestClient/JiraClient.cs
+++ b/TechTalk.JiraRestClient/JiraClient.cs
@@ -145,12 +145,24 @@ namespace TechTalk.JiraRestClient
 
         public Issue<TIssueFields> CreateIssue(String projectKey, String issueType, TIssueFields issueFields)
         {
+            return CreateIssue(projectKey, issueType, issueFields, null);
+        }
+
+        public Issue<TIssueFields> CreateIssue(String projectKey, String issueType, TIssueFields issueFields, Dictionary<string, object> customFields)
+        {
             try
             {
                 var request = CreateRequest(Method.POST, "issue");
                 request.AddHeader("ContentType", "application/json");
 
                 var issueData = new Dictionary<string, object>();
+
+                if(customFields != null)
+                {
+                    foreach(var customField in customFields)
+                        issueData.Add(customField.Key, customField.Value);
+                }
+
                 issueData.Add("project", new { key = projectKey });
                 issueData.Add("issuetype", new { name = issueType });
 
@@ -187,6 +199,11 @@ namespace TechTalk.JiraRestClient
 
         public Issue<TIssueFields> UpdateIssue(Issue<TIssueFields> issue)
         {
+            return UpdateIssue(issue, null);
+        }
+
+        public Issue<TIssueFields> UpdateIssue(Issue<TIssueFields> issue, Dictionary<string, object> customFields)
+        {
             try
             {
                 var path = String.Format("issue/{0}", issue.JiraIdentifier);
@@ -194,6 +211,13 @@ namespace TechTalk.JiraRestClient
                 request.AddHeader("ContentType", "application/json");
 
                 var updateData = new Dictionary<string, object>();
+
+                if (customFields != null)
+                {
+                    foreach (var customField in customFields)
+                        updateData.Add(customField.Key, new[] { new { set = customField.Value } });
+                }
+
                 if (issue.fields.summary != null)
                     updateData.Add("summary", new[] { new { set = issue.fields.summary } });
                 if (issue.fields.description != null)


### PR DESCRIPTION
I wrote the reason why the change would be useful here: https://github.com/techtalk/JiraRestClient/pull/14

It will be really hard for me to make my app work without both pull requests, i really hope you consider the change. I already tested locally.

How i am using this part:

``` C#
var issue = jiraClient.CreateIssue(ConfigurationManager.AppSettings["JiraDefaultProject"], "Task", new CustomIssueFields
{
    summary = v.Titulo
}, new Dictionary<string, object>
{
    { ConfigurationManager.AppSettings["JiraCustomFieldMySuiteTicket"], v.Codigo }
});
```
