### PR TITLE
empty label array

### DIFF
--- a/TechTalk.JiraRestClient/JiraClient.cs
+++ b/TechTalk.JiraRestClient/JiraClient.cs
@@ -189,7 +189,7 @@ namespace TechTalk.JiraRestClient
                     issueData.Add("summary", issueFields.summary);
                 if (issueFields.description != null)
                     issueData.Add("description", issueFields.description);
-                if (issueFields.labels != null)
+                if (issueFields.labels != null && issueFields.labels.Count > 0)
                     issueData.Add("labels", issueFields.labels);
                 if (issueFields.timetracking != null)
                     issueData.Add("timetracking", new { originalEstimate = issueFields.timetracking.originalEstimate });


### PR DESCRIPTION
It seems in some instances jira will throw an error if you attempt to create an issue with a labels node that is an empty array. Check for it first.
